### PR TITLE
fix to fetch only needed data => less data transfer

### DIFF
--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -68,7 +68,8 @@ export default function NavigationBar() {
 								</LinkContainer>
 
 								<LinkContainer to="/issues">
-									<Nav.Link>Issues ({issues.length})</Nav.Link>
+									{/* <Nav.Link>Issues ({issues.length})</Nav.Link> */}
+									<Nav.Link>Issues</Nav.Link>
 								</LinkContainer>
 								<LinkContainer
 									to={createAddIssueLinkWithParams(

--- a/src/context/useProjects.tsx
+++ b/src/context/useProjects.tsx
@@ -214,13 +214,6 @@ export function ProjectsProvider({ children }: ProjectsProviderProps) {
 				const docRef = doc(firestore, "user-projects", uid);
 				const docSnap = await getDoc(docRef);
 
-				// if (docSnap.exists()) {
-				// 	console.log("User projects document data:", docSnap.data());
-				// } else {
-				// 	// docSnap.data() will be undefined in this case
-				// 	console.log("No user projects document!");
-				// }
-
 				const userProjectsDoc = docSnap.data();
 
 				// then if there are user projects ids,

--- a/src/context/useRootContext.tsx
+++ b/src/context/useRootContext.tsx
@@ -1,0 +1,150 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import logError from "../lib/logError";
+import useIssues from "./useIssues";
+import useProjects from "./useProjects";
+import useUser from "./useUser";
+import { Project } from "../interfaces/Project";
+import { doc, getDoc } from "firebase/firestore";
+import { firestore } from "../firebaseConfig";
+import { Issue } from "../interfaces/Issue";
+import rankifyIssues from "../lib/rankifyIssues";
+
+const RootContext = createContext<{
+	fetchProjectIssues: (project: Project.Project) => Promise<void>;
+	fetchAllIssues: () => Promise<void>;
+} | null>(null);
+
+export default function useRootContext() {
+	const context = useContext(RootContext);
+
+	if (!context) {
+		throw new Error(
+			"useRootContext has to be used within <RootContext.Provider>"
+		);
+	}
+
+	return context;
+}
+
+type RootContextProviderProps = {
+	children: React.ReactNode;
+};
+
+export function RootContextProvider({ children }: RootContextProviderProps) {
+	const { user } = useUser();
+	const { issues, setIssues } = useIssues();
+	const { projects } = useProjects();
+
+	const [fetchedProjects, setFetchedProjects] = useState<string[]>([]); // array that contains the ids of projects whose issues are already fetched
+
+	async function fetchProjectIssues(project: Project.Project) {
+		if (!project || !user) return;
+
+		console.info(`Fetching ${project.title} project's issues...`);
+
+		if (fetchedProjects.length && fetchedProjects.includes(project.id)) {
+			console.warn(
+				`${project.title} issues are already fetched. No need to fetch it again.`
+			);
+			return;
+		}
+
+		try {
+			// fetch project's issuesIds array:
+
+			const docRef = doc(firestore, "project-issues", project.id);
+			const docSnap = await getDoc(docRef);
+
+			const projectIssuesDoc = docSnap.data();
+
+			// then if there are project issues ids,
+			// fetch those issues data:
+
+			if (projectIssuesDoc) {
+				const issuesIds: string[] = projectIssuesDoc.issuesIds;
+				console.log(`${project.title} project's issues ids: ${issuesIds}`);
+
+				const fetchedProjectIssues = await Promise.all(
+					issuesIds.map(async (issueId) => {
+						const docRef = doc(firestore, "issues", issueId);
+						const docSnap = await getDoc(docRef);
+						if (docSnap.exists()) {
+							return docSnap.data() as Issue.DbIssue;
+						}
+					})
+				);
+
+				if (fetchedProjectIssues) {
+					const filteredIssues = fetchedProjectIssues.filter(
+						(issue) => issue !== undefined
+					) as Issue.DbIssue[];
+
+					// rankify issues & add to app state:
+					const rankifiedProjectIssues = rankifyIssues(filteredIssues);
+
+					// check if there are no duplicated issues:
+					const issuesIds = issues.map((i) => i.id);
+					const rankifiedProjectIssuesIds = rankifiedProjectIssues.map(
+						(i) => i.id
+					);
+					const uniqueIds = rankifiedProjectIssuesIds.filter(
+						(id) => !issuesIds.includes(id)
+					);
+					const uniqueFetchedProjectIssues: Issue.AppIssue[] =
+						rankifiedProjectIssues.filter((i) => uniqueIds.includes(i.id));
+
+					setFetchedProjects([...fetchedProjects, project.id]);
+					setIssues([...issues, ...uniqueFetchedProjectIssues]);
+				}
+			} else {
+				console.warn(
+					`There are no issues in ${project.title} project so far...`
+				);
+			}
+		} catch (error: any) {
+			if (error.code === "not-found") {
+				// Handle case where collection doesn't exist
+				logError(error.message);
+			} else {
+				// Handle other errors
+				logError(error.message);
+			}
+		}
+	}
+
+	async function fetchAllIssues() {
+		if (!user) return;
+
+		console.info(`Fetching all user's issues...`);
+
+		const allProjectsIds = projects.map((p) => p.id);
+
+		const notFetchedProjectsIds = allProjectsIds.filter(
+			(id) => !fetchedProjects.includes(id)
+		);
+
+		if (notFetchedProjectsIds.length) {
+			console.warn(
+				"Need to fetch issues related to projects of ids:",
+				notFetchedProjectsIds
+			);
+
+			notFetchedProjectsIds.forEach((id) => {
+				const project: Project.Project | undefined = projects.find(
+					(p) => p.id === id
+				);
+				if (project) {
+					return fetchProjectIssues(project);
+				}
+			});
+		} else {
+			console.info(
+				"There are all issues from all projects fetched already. No need to fetch them again."
+			);
+		}
+	}
+
+	const value = { fetchProjectIssues, fetchAllIssues };
+
+	return <RootContext.Provider value={value}>{children}</RootContext.Provider>;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "./context/useTheme";
 import { ProjectsProvider } from "./context/useProjects";
 import { MaxWidthProvider } from "./context/useMaxWidth";
 import { IssuesProvider } from "./context/useIssues";
+import { RootContextProvider } from "./context/useRootContext";
 
 const root = ReactDOM.createRoot(
 	document.getElementById("root") as HTMLElement
@@ -21,7 +22,9 @@ root.render(
 				<UserProvider>
 					<IssuesProvider>
 						<ProjectsProvider>
-							<App />
+							<RootContextProvider>
+								<App />
+							</RootContextProvider>
 						</ProjectsProvider>
 					</IssuesProvider>
 				</UserProvider>

--- a/src/pages/Issue/index.tsx
+++ b/src/pages/Issue/index.tsx
@@ -5,14 +5,21 @@ import { Button, Badge } from "react-bootstrap";
 import useIssues from "../../context/useIssues";
 import MarkdownRenderer from "../../components/MarkdownRenderer";
 import IssueTable from "./IssueTable";
+import { useEffect } from "react";
 
 export default function Issue() {
 	const { issueId } = useParams<string>();
 	const { projects } = useProjects();
-	const { issues, deleteIssue } = useIssues();
+	const { issues, deleteIssue, fetchIssue } = useIssues();
 	const issue = issues.find((i) => i.id === issueId);
 	const project = projects.find((p) => p.id === issue?.projectId);
 	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (issueId) {
+			fetchIssue(issueId);
+		}
+	}, [issueId]);
 
 	if (!issue || !issueId)
 		return <p className="text-center text-danger">There is no such issue...</p>;

--- a/src/pages/Issues/index.tsx
+++ b/src/pages/Issues/index.tsx
@@ -1,21 +1,19 @@
 import useIssues from "../../context/useIssues";
-import Spinner from "react-bootstrap/Spinner";
 import { Link } from "react-router-dom";
 import PageHeader from "../../components/Layout/PageHeader";
 import IssuesFilterableTable from "./IssuesFilterableTable";
 import { AiOutlinePlusSquare } from "react-icons/ai";
 import createAddIssueLinkWithParams from "../../lib/createAddIssueLinkWithParams";
+import useRootContext from "../../context/useRootContext";
+import { useEffect } from "react";
 
 export default function Issues() {
-	const { issues, loading } = useIssues();
+	const { issues } = useIssues();
+	const { fetchAllIssues } = useRootContext();
 
-	function Loading() {
-		return (
-			<div className="text-center">
-				<Spinner />
-			</div>
-		);
-	}
+	useEffect(() => {
+		fetchAllIssues();
+	}, []);
 
 	function NoIssues() {
 		return <p className="text-center">There are no issues... Add one!</p>;
@@ -36,9 +34,7 @@ export default function Issues() {
 				}
 			></PageHeader>
 
-			{loading ? (
-				<Loading />
-			) : issues && issues.length ? (
+			{issues && issues.length ? (
 				<IssuesFilterableTable issues={issues} />
 			) : (
 				<NoIssues />

--- a/src/pages/Project/index.tsx
+++ b/src/pages/Project/index.tsx
@@ -3,10 +3,13 @@ import useProjects from "../../context/useProjects";
 import PageHeader from "../../components/Layout/PageHeader";
 import { BsPencilSquare, BsTrash } from "react-icons/bs";
 import useIssues from "../../context/useIssues";
+import { useEffect } from "react";
+import useRootContext from "../../context/useRootContext";
 
 export default function Project() {
 	const { projectId } = useParams<string>();
 	const { projects, deleteProject } = useProjects();
+	const { fetchProjectIssues } = useRootContext();
 	const project = projects.find((p) => p.id === projectId);
 	const navigate = useNavigate();
 
@@ -27,6 +30,12 @@ export default function Project() {
 			navigate("/projects");
 		}
 	}
+
+	useEffect(() => {
+		if (project) {
+			fetchProjectIssues(project);
+		}
+	}, [project]);
 
 	// TODO: make "issues view" the root view for project page:
 	// useEffect(() => navigate("issues"), []); // this is just a workaround for now


### PR DESCRIPTION
- when user logs in => fetch user's projects' data;
- when user visits /project page => fetch all projects' issues, if not fetched before
- when user visits /issues => fetch all user's issues, if not fetched before or fetch only missing issues from projects that hasn't been fetched;
- when user visits /issue page => fetch issue, if not fetched before;
- create root context to be able to use all contexts in one place; for now use it for new fetchProjectIssues() & fetchAllIssues